### PR TITLE
Ensure returning admins regain controls on reconnect

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,26 +19,71 @@ app.get('/create-session', (req, res) => {
   sessions[sessionId] = {
     users: {},
     votesRevealed: false,
-    admin: null
+    adminName: null
   };
   res.json({ sessionId });
 });
 
 io.on('connection', (socket) => {
-  socket.on('join', ({ sessionId, name }) => {
+  socket.on('join', ({ sessionId, name }, callback = () => {}) => {
     if (!sessions[sessionId]) {
-      socket.emit('error', 'Session does not exist.');
+      callback({ success: false, message: 'Session does not exist.' });
       return;
     }
     const session = sessions[sessionId];
-    const isAdmin = Object.keys(session.users).length === 0;
-    session.users[socket.id] = { name, vote: null, isAdmin };
+    const trimmedName = (name || '').trim();
+    if (!trimmedName) {
+      callback({ success: false, message: 'A name is required to join the session.' });
+      return;
+    }
+
+    const normalizedName = trimmedName.toLowerCase();
+    const currentAdminEntry = Object.values(session.users).find(user => user.isAdmin);
+    const isReturningAdmin = session.adminName === normalizedName;
+    let isAdmin = false;
+
+    if (isReturningAdmin) {
+      isAdmin = true;
+      Object.values(session.users).forEach(user => {
+        user.isAdmin = false;
+      });
+    } else if (!currentAdminEntry) {
+      if (!session.adminName) {
+        isAdmin = true;
+        session.adminName = normalizedName;
+      }
+    }
+
+    if (isAdmin) {
+      session.adminName = normalizedName;
+    }
+
+    const existingUserId = Object.keys(session.users).find(id => {
+      const userName = session.users[id]?.name || '';
+      return userName.trim().toLowerCase() === normalizedName;
+    });
+
+    if (existingUserId) {
+      delete session.users[existingUserId];
+    }
+
+    session.users[socket.id] = { name: trimmedName, vote: null, isAdmin };
     socket.join(sessionId);
     socket.sessionId = sessionId;
-    io.to(sessionId).emit('state', {
+
+    const state = {
       users: session.users,
       votesRevealed: session.votesRevealed
+    };
+
+    callback({
+      success: true,
+      isAdmin,
+      selfId: socket.id,
+      state
     });
+
+    io.to(sessionId).emit('state', state);
   });
 
   socket.on('vote', (value) => {

--- a/public/index.html
+++ b/public/index.html
@@ -29,7 +29,7 @@
     </div>
   </div>
 
-  <script src="/socket.io/socket.io.js"></script>
+  <script src="https://cdn.socket.io/4.7.2/socket.io.min.js" crossorigin="anonymous"></script>
   <script>
     const socket = io();
     const joinBtn = document.getElementById('join');
@@ -37,16 +37,43 @@
     const sessionIdInput = document.getElementById('sessionId');
     const votePanel = document.getElementById('vote-panel');
     const usersDiv = document.getElementById('users');
+    const revealBtn = document.getElementById('reveal');
+    const clearBtn = document.getElementById('clear');
 
-    let sessionId;
+    let selfId;
+
+    const renderState = ({ users, votesRevealed }) => {
+      usersDiv.innerHTML = '';
+      const currentUser = selfId ? users[selfId] : undefined;
+      setAdminControlsState(Boolean(currentUser?.isAdmin));
+
+      Object.values(users).forEach(({ name, vote }) => {
+        const displayVote = votesRevealed ? vote : (vote ? '✓' : '');
+        usersDiv.innerHTML += `<div class="p-2 border-b">${name}: <strong>${displayVote ?? ''}</strong></div>`;
+      });
+    };
 
     joinBtn.addEventListener('click', () => {
-      const name = nameInput.value;
-      sessionId = sessionIdInput.value;
-      if (name && sessionId) {
-        socket.emit('join', { sessionId, name });
-        votePanel.classList.remove('hidden');
+      const name = nameInput.value.trim();
+      const sessionId = sessionIdInput.value.trim();
+
+      if (!name || !sessionId) {
+        alert('Both name and session ID are required.');
+        return;
       }
+
+      socket.emit('join', { sessionId, name }, (response) => {
+        if (!response || !response.success) {
+          const message = response?.message || 'Unable to join the session. Please try again.';
+          alert(message);
+          return;
+        }
+
+        selfId = response.selfId;
+        votePanel.classList.remove('hidden');
+        setAdminControlsState(response.isAdmin);
+        renderState(response.state);
+      });
     });
 
     document.querySelectorAll('.vote-btn').forEach(btn => {
@@ -55,20 +82,39 @@
       });
     });
 
-    document.getElementById('reveal').addEventListener('click', () => {
+    const setAdminControlsState = (isAdmin) => {
+      const controls = [revealBtn, clearBtn];
+      controls.forEach(btn => {
+        btn.disabled = !isAdmin;
+        btn.classList.toggle('opacity-50', !isAdmin);
+        btn.classList.toggle('cursor-not-allowed', !isAdmin);
+      });
+    };
+
+    setAdminControlsState(false);
+
+    revealBtn.addEventListener('click', () => {
       socket.emit('reveal');
     });
 
-    document.getElementById('clear').addEventListener('click', () => {
+    clearBtn.addEventListener('click', () => {
       socket.emit('clear');
     });
 
-    socket.on('state', ({ users, votesRevealed }) => {
-      usersDiv.innerHTML = '';
-      for (const id in users) {
-        const { name, vote } = users[id];
-        const displayVote = votesRevealed ? vote : (vote ? '✓' : '');
-        usersDiv.innerHTML += `<div class="p-2 border-b">${name}: <strong>${displayVote}</strong></div>`;
+    socket.on('state', (state) => {
+      if (state?.users) {
+        renderState(state);
+      }
+    });
+
+    socket.on('disconnect', () => {
+      selfId = undefined;
+      setAdminControlsState(false);
+    });
+
+    socket.on('error', (message) => {
+      if (typeof message === 'string') {
+        alert(message);
       }
     });
   </script>


### PR DESCRIPTION
## Summary
- acknowledge join requests with admin status and the current session state so reconnecting admins immediately regain their controls
- update the client to wait for join confirmation, track the active socket id, and restore admin buttons after reconnects
- load the Socket.IO client from the CDN and surface join validation errors so the static deployment renders correctly

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68e5553718a48323b6e0de1de8c23740