### PR TITLE
Preserve admin privileges on rejoin

### DIFF
--- a/functions/join.js
+++ b/functions/join.js
@@ -17,7 +17,9 @@ export async function onRequestPost({ request, env }) {
       session.users = {};
     }
 
-    const isAdmin = Object.keys(session.users).length === 0;
+    const existingUser = session.users[userName];
+    const hasAdmin = Object.values(session.users).some(user => user.isAdmin);
+    const isAdmin = existingUser?.isAdmin ?? !hasAdmin;
 
     session.users[userName] = {
       name: userName,


### PR DESCRIPTION
## Summary
- retain an existing user's admin flag when they rejoin a session so they keep reveal and clear access
- fall back to assigning admin to the first user when no admin exists in the session

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e5626425988323b22738f8cbce8e12