### PR TITLE
Fix admin remove button hover flicker

### DIFF
--- a/index.html
+++ b/index.html
@@ -506,7 +506,8 @@ sortedUsers.forEach(user => {
     removeBtn.type = 'button';
     removeBtn.textContent = '✕';
     removeBtn.title = `Remove ${user.name}`;
-    removeBtn.className = 'text-red-500 hover:text-red-700 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity duration-200 px-2 py-1 rounded focus:outline-none';
+    removeBtn.dataset.removeUser = user.name;
+    removeBtn.className = 'text-red-500 hover:text-red-700 opacity-0 pointer-events-none focus-visible:opacity-100 transition-opacity duration-200 px-2 py-1 rounded focus:outline-none';
     removeBtn.onclick = (event) => {
       event.stopPropagation();
       removeUser(user.name);
@@ -517,6 +518,18 @@ sortedUsers.forEach(user => {
   const voteCell = document.createElement('div');
   voteCell.className = 'text-right pr-2';
   voteCell.innerHTML = vote;
+
+  row.addEventListener('pointerenter', () => {
+    hoveredRemoveUser = user.name;
+    syncRemoveButtonVisibility();
+  });
+
+  row.addEventListener('pointerleave', () => {
+    if (hoveredRemoveUser === user.name) {
+      hoveredRemoveUser = null;
+    }
+    syncRemoveButtonVisibility();
+  });
 
   row.appendChild(nameCell);
   row.appendChild(voteCell);


### PR DESCRIPTION
## Summary
- track the currently hovered row so the admin remove button stays visible without flickering
- toggle opacity and pointer events based on the hovered user to avoid CSS/JS conflicts during polling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5690f58f48323acce63af21e57146