### PR TITLE
Reset cleared cards to default hover state

### DIFF
--- a/index.html
+++ b/index.html
@@ -246,7 +246,12 @@ function renderCards() {
     
     existingCards.forEach((card, index) => {
       const value = fibonacci[index];
-      card.classList.remove('bg-blue-300', 'dark:bg-blue-700');
+      card.classList.remove(
+        'bg-blue-300',
+        'dark:bg-blue-700',
+        'hover:bg-blue-300',
+        'dark:hover:bg-blue-700'
+      );
       if (currentUser && currentUser.vote === value) {
   card.classList.add(
     'bg-blue-300',
@@ -275,7 +280,12 @@ function renderCards() {
   if (votesRevealed && !isAdmin) return;
 
   document.querySelectorAll('.card').forEach(c => {
-    c.classList.remove('bg-blue-300', 'dark:bg-blue-700');
+    c.classList.remove(
+      'bg-blue-300',
+      'dark:bg-blue-700',
+      'hover:bg-blue-300',
+      'dark:hover:bg-blue-700'
+    );
   });
 
   card.classList.add('bg-blue-300', 'dark:bg-blue-700');
@@ -339,7 +349,12 @@ function clearVotes() {
 
     // 🔽 Clear selected card highlight
     document.querySelectorAll('.card').forEach(c => {
-      c.classList.remove('bg-blue-300', 'dark:bg-blue-700');
+      c.classList.remove(
+        'bg-blue-300',
+        'dark:bg-blue-700',
+        'hover:bg-blue-300',
+        'dark:hover:bg-blue-700'
+      );
     });
   });
 }


### PR DESCRIPTION
## Summary
- remove the active hover styling from poker cards whenever votes are cleared or cards are re-rendered so they return to the default hover look
- ensure selecting a different card immediately clears the previous selection's active hover styling

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68e56c9ca0448323b12a4ebf7cb76eec