### PR TITLE
Adjust client polling cadence to reduce worker usage

### DIFF
--- a/index.html
+++ b/index.html
@@ -190,8 +190,8 @@ document.getElementById('name').focus();
     let hoveredRemoveUser = null;
     window._notifiedOnce = false;
     window.fetchInterval = null;
-    const ACTIVE_POLL_INTERVAL = 200;
-    const REVEALED_POLL_INTERVAL = 1500;
+    const ACTIVE_POLL_INTERVAL = 500;
+    const REVEALED_POLL_INTERVAL = 3000;
     let currentPollInterval = null;
 
     function toggleDarkMode() {


### PR DESCRIPTION
## Summary
- increase the active polling interval back to 500ms
- restore the 3s polling cadence once votes have been revealed to reduce worker requests

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e812e18da08323a1b89e90706ce75e