### PR TITLE
Throttle client polling to curb worker traffic

### DIFF
--- a/index.html
+++ b/index.html
@@ -189,10 +189,16 @@ document.getElementById('name').focus();
     let votesRevealed = false;
     let hoveredRemoveUser = null;
     window._notifiedOnce = false;
-    window.fetchInterval = null;
-    const ACTIVE_POLL_INTERVAL = 200;
-    const REVEALED_POLL_INTERVAL = 1500;
-    let currentPollInterval = null;
+    let pollTimeoutId = null;
+    const ACTIVE_POLL_INTERVAL = 500;
+    const REVEALED_POLL_INTERVAL = 3000;
+    const HIDDEN_POLL_INTERVAL = 12000;
+    let desiredPollInterval = null;
+    let basePollInterval = ACTIVE_POLL_INTERVAL;
+    let visibilityOverrideInterval = null;
+    let pollingEnabled = false;
+    let isFetchingState = false;
+    let lastFetchPromise = null;
 
     function toggleDarkMode() {
       document.documentElement.classList.toggle('dark');
@@ -223,24 +229,82 @@ document.getElementById('name').focus();
   });
 }
 
-function startPolling(interval = ACTIVE_POLL_INTERVAL) {
-  if (window.fetchInterval) clearInterval(window.fetchInterval);
-  window.fetchInterval = setInterval(fetchSessionState, interval);
-  currentPollInterval = interval;
+function scheduleNextPoll() {
+  if (desiredPollInterval == null) return;
+
+  pollTimeoutId = setTimeout(async () => {
+    pollTimeoutId = null;
+
+    try {
+      await fetchSessionState();
+    } finally {
+      if (desiredPollInterval != null) {
+        scheduleNextPoll();
+      }
+    }
+  }, desiredPollInterval);
 }
-function stopPolling() {
-  if (window.fetchInterval) {
-    clearInterval(window.fetchInterval);
-    window.fetchInterval = null;
+
+function updatePollingSchedule() {
+  if (!pollingEnabled) {
+    desiredPollInterval = null;
+    if (pollTimeoutId) {
+      clearTimeout(pollTimeoutId);
+      pollTimeoutId = null;
+    }
+    return;
   }
-  currentPollInterval = null;
+
+  const nextInterval = visibilityOverrideInterval ?? basePollInterval;
+  if (desiredPollInterval === nextInterval) return;
+
+  desiredPollInterval = nextInterval;
+
+  if (pollTimeoutId) {
+    clearTimeout(pollTimeoutId);
+    pollTimeoutId = null;
+  }
+
+  if (desiredPollInterval != null) {
+    scheduleNextPoll();
+  }
+}
+
+function startPolling(interval = ACTIVE_POLL_INTERVAL) {
+  stopPolling();
+  pollingEnabled = true;
+  basePollInterval = interval;
+  updatePollingSchedule();
+}
+
+function stopPolling() {
+  pollingEnabled = false;
+  desiredPollInterval = null;
+  if (pollTimeoutId) {
+    clearTimeout(pollTimeoutId);
+    pollTimeoutId = null;
+  }
 }
 
 function ensurePollingInterval(interval) {
-  if (currentPollInterval !== interval) {
-    startPolling(interval);
+  if (basePollInterval !== interval) {
+    basePollInterval = interval;
+    updatePollingSchedule();
   }
 }
+
+document.addEventListener('visibilitychange', () => {
+  visibilityOverrideInterval = document.hidden ? HIDDEN_POLL_INTERVAL : null;
+  updatePollingSchedule();
+});
+
+window.addEventListener('beforeunload', stopPolling);
+window.addEventListener('pagehide', stopPolling);
+window.addEventListener('pageshow', () => {
+  if (!pollingEnabled && sessionId && userName) {
+    startPolling(votesRevealed ? REVEALED_POLL_INTERVAL : ACTIVE_POLL_INTERVAL);
+  }
+});
 
 
 
@@ -309,7 +373,7 @@ function renderCards() {
     method: 'POST',
     body: JSON.stringify({ sessionId, userName, vote: value }),
     headers: { 'Content-Type': 'application/json' }
-  }).then(fetchSessionState);
+  }).then(() => fetchSessionState());
 };
 
 
@@ -322,7 +386,15 @@ function renderCards() {
 
 
 function fetchSessionState() {
-  fetch(`/state?sessionId=${sessionId}`)
+  if (!sessionId) return Promise.resolve();
+
+  if (isFetchingState) {
+    return lastFetchPromise;
+  }
+
+  isFetchingState = true;
+
+  lastFetchPromise = fetch(`/state?sessionId=${sessionId}`)
     .then(res => {
       if (!res.ok) throw new Error('Failed to fetch session state.');
       return res.json();
@@ -332,7 +404,12 @@ function fetchSessionState() {
     })
     .catch(err => {
       console.error("Failed to fetch session state:", err);
+    })
+    .finally(() => {
+      isFetchingState = false;
     });
+
+  return lastFetchPromise;
 }
 
 
@@ -342,9 +419,7 @@ function revealVotes() {
     method: 'POST',
     body: JSON.stringify({ sessionId }),
     headers: { 'Content-Type': 'application/json' }
-  }).then(() => {
-    fetchSessionState(); // 👈 Refresh state immediately
-  });
+  }).then(() => fetchSessionState()); // 👈 Refresh state immediately
 }
 
 


### PR DESCRIPTION
## Summary
- replace the fixed setInterval polling with a sequential scheduler so requests never overlap and only run when enabled
- slow polling when the tab is hidden, resume the active cadence when visible again, and guard against duplicate fetches to trim redundant worker calls

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e812e18da08323a1b89e90706ce75e