### PR TITLE
Add shared reveal/clear toggle for new sessions

### DIFF
--- a/functions/create-session.js
+++ b/functions/create-session.js
@@ -1,13 +1,16 @@
 import { saveSession } from './lib/session.js';
 import { nanoid } from 'nanoid';
 
-export async function onRequestGet({ env }) {
+export async function onRequestGet({ request, env }) {
   try {
     const sessionId = nanoid(8);
+    const url = new URL(request.url);
+    const allowSharedControls = url.searchParams.get('allowSharedControls') === 'true';
 
     const session = {
       users: {},
       revealed: false,
+      allowSharedControls,
     };
 
     await saveSession(env, sessionId, session);

--- a/functions/state.js
+++ b/functions/state.js
@@ -34,6 +34,7 @@ export async function onRequestGet({ request, env }) {
       JSON.stringify({
         users: session.users,
         revealed: session.revealed || false,
+        allowSharedControls: session.allowSharedControls || false,
         triggerSound: session.triggerSoundSent || null // return timestamp
       }),
       { headers: { 'Content-Type': 'application/json' } }

--- a/index.html
+++ b/index.html
@@ -59,6 +59,12 @@ tailwind.config = {
       <label for="name" class="block text-sm text-gray-600 dark:text-gray-300 text-left">Your Name</label>
       <input id="name" placeholder="Your Name" class="w-full p-3 border rounded" autofocus autocomplete="off" />
 </div>
+      <div id="allowSharedControlsField" class="flex items-start gap-3 rounded border border-gray-200 dark:border-gray-700 bg-white/60 dark:bg-gray-800/60 px-3 py-2 text-left">
+        <input id="allowSharedControls" type="checkbox" class="mt-1 h-4 w-4 accent-green-500" />
+        <label for="allowSharedControls" class="text-sm text-gray-600 dark:text-gray-300">
+          Allow invited users to reveal and clear votes
+        </label>
+      </div>
       <div class="flex flex-col sm:flex-row sm:gap-4 gap-2">
       <button
   type="submit"
@@ -129,18 +135,20 @@ tailwind.config = {
 
 
 
-  window.addEventListener('DOMContentLoaded', () => {
+window.addEventListener('DOMContentLoaded', () => {
   const urlParts = window.location.pathname.split('/');
   const maybeSessionId = urlParts[1];
   if (maybeSessionId && maybeSessionId.length >= 6) {
     sessionId = maybeSessionId; // ✅ Assign to global
     const sessionInput = document.getElementById('sessionId');
     const createBtn = document.getElementById('createSessionBtn');
+    const allowSharedControlsField = document.getElementById('allowSharedControlsField');
 
     sessionInput.value = sessionId;
     const sessionField = document.getElementById('sessionField');
 if (sessionField) sessionField.style.display = 'none';
     if (createBtn) createBtn.style.display = 'none';
+    if (allowSharedControlsField) allowSharedControlsField.style.display = 'none';
   }
 });
 
@@ -180,7 +188,9 @@ function clearError() {
 }
 
     function createSession() {
-  fetch('/create-session')
+  const allowSharedControls = document.getElementById('allowSharedControls')?.checked;
+  const query = allowSharedControls ? '?allowSharedControls=true' : '';
+  fetch(`/create-session${query}`)
     .then(res => {
       if (!res.ok) throw new Error('Failed to create session.');
       return res.json();
@@ -540,6 +550,7 @@ function renderSessionState(session) {
 
   const { users, revealed } = session; // 👈 use 'revealed' directly
   votesRevealed = revealed ?? false;
+  const allowSharedControls = session.allowSharedControls ?? false;
 
 // 🔊 Handle server-triggered sound
 if (
@@ -575,9 +586,13 @@ if (
 
 if (currentUser?.isAdmin) {
   isAdmin = true;
-  document.getElementById('adminControls').classList.remove('hidden');
 } else {
   isAdmin = false;
+}
+
+if (currentUser?.isAdmin || allowSharedControls) {
+  document.getElementById('adminControls').classList.remove('hidden');
+} else {
   document.getElementById('adminControls').classList.add('hidden');
 }
 


### PR DESCRIPTION
### Motivation
- Allow a session creator to optionally let invited users access the reveal and clear controls so anyone can act as admin, with the feature off by default.
- Provide a simple toggle in the create-session flow and hide that option when a user is joining an existing session via URL.

### Description
- Add a checkbox `#allowSharedControls` to `index.html` and hide its field when autofilling a session from the URL, and send the selection as a query param from `createSession()` (e.g. `?allowSharedControls=true`).
- Persist `allowSharedControls` on session creation in `functions/create-session.js` by reading `request.url` and storing the flag on the saved session.
- Surface the flag in the session payload from `functions/state.js` by returning `allowSharedControls` in the response.
- Update client-side rendering in `index.html` so `#adminControls` is shown when `currentUser.isAdmin || allowSharedControls`, and adjust related admin visibility logic accordingly.

### Testing
- Started a local static server with `python -m http.server 8000` and ran a Playwright script to load `index.html` and capture a screenshot, which completed successfully.
- No unit tests or automated backend tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970fc1510d883239d924cfd2468080c)