### PR TITLE
Add coffee estimate card equivalent to question mark

### DIFF
--- a/index.html
+++ b/index.html
@@ -211,7 +211,17 @@ document.getElementById('createSessionBtn')?.addEventListener('click', createSes
 document.getElementById('name').focus();
 
     
-    const fibonacci = [0, 1, 2, 3, 5, 8, 13, '?'];
+    const cards = [
+      { label: 0, value: 0 },
+      { label: 1, value: 1 },
+      { label: 2, value: 2 },
+      { label: 3, value: 3 },
+      { label: 5, value: 5 },
+      { label: 8, value: 8 },
+      { label: 13, value: 13 },
+      { label: '?', value: '?' },
+      { label: '☕', value: '?' }
+    ];
     let isAdmin = false;
     let votesRevealed = false;
     let hoveredRemoveUser = null;
@@ -356,10 +366,10 @@ function renderCards() {
   const existingCards = container.querySelectorAll('.card');
   const currentUser = sessionUsers?.[userName];
   // If count hasn't changed, just update highlights
-  if (existingCards.length === fibonacci.length) {
+  if (existingCards.length === cards.length) {
     
     existingCards.forEach((card, index) => {
-      const value = fibonacci[index];
+      const value = cards[index].value;
       card.classList.remove(
         'bg-blue-300',
         'dark:bg-blue-700',
@@ -380,13 +390,13 @@ function renderCards() {
 
   // Otherwise, fully re-render
   container.innerHTML = '';
-  fibonacci.forEach(value => {
+  cards.forEach(cardConfig => {
     const card = document.createElement('div');
     card.className = 'card w-20 h-28 flex items-center justify-center border border-gray-400 dark:border-gray-600 rounded shadow bg-white dark:bg-gray-800 text-xl font-bold cursor-pointer transform transition-all duration-200 hover:scale-105 hover:shadow-lg hover:bg-blue-100 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500';
-    card.textContent = value;
+    card.textContent = cardConfig.label;
 
     const currentUser = sessionUsers?.[userName];
-    if (currentUser && currentUser.vote === value) {
+    if (currentUser && currentUser.vote === cardConfig.value) {
       card.classList.add('bg-blue-300', 'dark:bg-blue-700');
     }
 
@@ -410,7 +420,7 @@ function renderCards() {
 
   fetch('/vote', {
     method: 'POST',
-    body: JSON.stringify({ sessionId, userName, vote: value }),
+    body: JSON.stringify({ sessionId, userName, vote: cardConfig.value }),
     headers: { 'Content-Type': 'application/json' }
   }).then(() => fetchSessionState());
 };


### PR DESCRIPTION
### Motivation

- Add a coffee emoji card that acts like the existing unknown estimate so users can select a ☕ option that maps to the question-mark vote.

### Description

- Replace the simple `fibonacci` array with a `cards` array of `{ label, value }` objects and include `{ label: '☕', value: '?' }` in `index.html`.
- Update `renderCards` to iterate `cards`, use `cardConfig.label` for display, and compare/highlight using `cardConfig.value` instead of raw array values.
- Update vote submission to send `cardConfig.value` in the `POST /vote` payload so the coffee card submits the same value as `?`.
- All changes are limited to `index.html` and adjust the UI logic and vote payload accordingly.

### Testing

- Started a local static server with `python -m http.server 8000`, which ran successfully. 
- Attempted to run a Playwright script to render the page and capture a screenshot, but the Chromium instance crashed/timed out and the screenshot step failed. 
- No other automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970fe4f70fc83238e8603fec97ab5e0)