### PR TITLE
Fix coffee card selection value

### DIFF
--- a/index.html
+++ b/index.html
@@ -220,7 +220,7 @@ document.getElementById('name').focus();
       { label: 8, value: 8 },
       { label: 13, value: 13 },
       { label: '?', value: '?' },
-      { label: '☕', value: '?' }
+      { label: '☕', value: '☕' }
     ];
     let isAdmin = false;
     let votesRevealed = false;


### PR DESCRIPTION
### Motivation
- The coffee card used the same vote value as the question mark card (`'?'`), causing selecting coffee to also highlight `?`.

### Description
- Update the cards array in `index.html` so the coffee card has its own value (`'☕'` instead of `'?'`).

### Testing
- No automated tests were run; a Playwright screenshot attempt was attempted but failed to load the page, so no visual verification was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697101b7eba483238df3c3453789a4f5)