### PR TITLE
Allow shared-control participants to remove users

### DIFF
--- a/functions/remove-user.js
+++ b/functions/remove-user.js
@@ -25,7 +25,9 @@ export async function onRequestPost({ request, env }) {
 
     const requestingUser = session.users[requestedBy];
 
-    if (!requestingUser || !requestingUser.isAdmin) {
+    const canRemoveUsers = requestingUser?.isAdmin || session.allowSharedControls;
+
+    if (!canRemoveUsers) {
       return new Response(JSON.stringify({ error: 'Only an admin can remove users' }), {
         status: 403,
         headers: { 'Content-Type': 'application/json' }

--- a/index.html
+++ b/index.html
@@ -224,6 +224,7 @@ document.getElementById('name').focus();
     ];
     let isAdmin = false;
     let votesRevealed = false;
+    let allowSharedControls = false;
     let hoveredRemoveUser = null;
     window._notifiedOnce = false;
     let pollTimeoutId = null;
@@ -518,7 +519,7 @@ function calculateStats(votes) {
 
 
 function removeUser(targetName) {
-  if (!isAdmin) return;
+  if (!isAdmin && !allowSharedControls) return;
 
   const confirmRemoval = confirm(`Remove ${targetName} from the session?`);
   if (!confirmRemoval) return;
@@ -560,7 +561,7 @@ function renderSessionState(session) {
 
   const { users, revealed } = session; // 👈 use 'revealed' directly
   votesRevealed = revealed ?? false;
-  const allowSharedControls = session.allowSharedControls ?? false;
+  allowSharedControls = session.allowSharedControls ?? false;
 
 // 🔊 Handle server-triggered sound
 if (
@@ -657,7 +658,7 @@ sortedUsers.forEach(user => {
   nameCell.className = 'text-left pl-2 flex items-center justify-between gap-2';
   nameCell.textContent = displayName;
 
-  if (isAdmin && user.name !== userName) {
+  if ((isAdmin || allowSharedControls) && user.name !== userName) {
     const removeBtn = document.createElement('button');
     removeBtn.type = 'button';
     removeBtn.textContent = '✕';


### PR DESCRIPTION
### Motivation
- When the session has `allowSharedControls` enabled, invited users who can reveal/clear votes should also be allowed to remove other users like an admin.

### Description
- Client-side (`index.html`) introduces a persistent `allowSharedControls` flag, reads it from session state, and shows the remove-`X` control when `isAdmin` or `allowSharedControls` is true.
- Client `removeUser` now permits removal if `isAdmin || allowSharedControls` and sends requests with `requestedBy` unchanged.
- Server-side (`functions/remove-user.js`) updates the permission check to allow removals when `requestingUser?.isAdmin || session.allowSharedControls` is true.
- Removal behavior for reassigning admin on admin deletion is left unchanged and session saving still occurs via `saveSession`.

### Testing
- Launched a local static server with `python -m http.server` and confirmed `curl -I http://127.0.0.1:8000/index.html` returned `200 OK` (succeeded).
- Attempted a Playwright smoke test to verify the UI and remove-button visibility, but the script timed out or could not find the expected DOM in the test environment (failed).
- No unit tests were added or executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971065d05ec8323b7a42b458bf504c6)