### PR TITLE
Secure voting API with per-user session tokens

### DIFF
--- a/functions/join.js
+++ b/functions/join.js
@@ -2,7 +2,7 @@ import { getSession, saveSession } from './lib/session.js';
 
 export async function onRequestPost({ request, env }) {
   try {
-    const { sessionId, userName } = await request.json();
+    const { sessionId, userName, userToken } = await request.json();
 
     if (!sessionId || !userName) {
       return new Response(JSON.stringify({ error: 'Missing sessionId or userName' }), {
@@ -17,19 +17,39 @@ export async function onRequestPost({ request, env }) {
       session.users = {};
     }
 
+    if (!session.userTokens) {
+      session.userTokens = {};
+    }
+
     const existingUser = session.users[userName];
+
+    if (existingUser) {
+      const existingToken = session.userTokens[userName];
+      if (!userToken || !existingToken || userToken !== existingToken) {
+        return new Response(JSON.stringify({ error: 'User name is already in use' }), {
+          status: 409,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+    }
+
     const hasAdmin = Object.values(session.users).some(user => user.isAdmin);
     const isAdmin = existingUser?.isAdmin ?? !hasAdmin;
+    const resolvedUserToken = existingUser
+      ? session.userTokens[userName]
+      : crypto.randomUUID();
+
+    session.userTokens[userName] = resolvedUserToken;
 
     session.users[userName] = {
       name: userName,
-      vote: null,
+      vote: existingUser?.vote ?? null,
       isAdmin,
     };
 
     await saveSession(env, sessionId, session);
 
-    return new Response(JSON.stringify({ success: true }), {
+    return new Response(JSON.stringify({ success: true, userToken: resolvedUserToken }), {
       headers: { 'Content-Type': 'application/json' },
     });
 

--- a/functions/remove-user.js
+++ b/functions/remove-user.js
@@ -45,6 +45,10 @@ export async function onRequestPost({ request, env }) {
 
     delete session.users[targetUser];
 
+    if (session.userTokens) {
+      delete session.userTokens[targetUser];
+    }
+
     if (removedWasAdmin) {
       const remainingUsers = Object.values(session.users);
       if (remainingUsers.length > 0) {

--- a/functions/vote.js
+++ b/functions/vote.js
@@ -2,7 +2,7 @@ import { getSession, saveSession } from './lib/session.js';
 
 export async function onRequestPost({ request, env }) {
   try {
-    const { sessionId, userName, vote } = await request.json();
+    const { sessionId, userName, userToken, vote } = await request.json();
 
     if (!sessionId || !userName) {
       return new Response(JSON.stringify({ error: 'Missing sessionId or userName' }), {
@@ -19,10 +19,13 @@ export async function onRequestPost({ request, env }) {
       });
     }
 
-    if (!session.users[userName]) {
-      session.users[userName] = { name: userName };
-    }
 
+    if (!session.users[userName] || !session.userTokens || !session.userTokens[userName] || session.userTokens[userName] !== userToken) {
+      return new Response(JSON.stringify({ error: 'Unauthorized vote update' }), {
+        status: 403,
+        headers: { 'Content-Type': 'application/json' }
+      });
+    }
     session.users[userName].vote = vote;
 
     await saveSession(env, sessionId, session);

--- a/index.html
+++ b/index.html
@@ -204,6 +204,7 @@ window.addEventListener('click', () => {
 
     let sessionId = '';
     let userName = '';
+    let userToken = null;
     let sessionUsers = {};
 
     let soundEnabled = false;
@@ -228,6 +229,19 @@ function clearError() {
 
   banner.textContent = '';
   banner.classList.add('hidden');
+}
+
+function getUserTokenStorageKey(sessionIdValue, userNameValue) {
+  return `poker:userToken:${sessionIdValue}:${userNameValue.toLowerCase()}`;
+}
+
+function getStoredUserToken(sessionIdValue, userNameValue) {
+  return localStorage.getItem(getUserTokenStorageKey(sessionIdValue, userNameValue));
+}
+
+function storeUserToken(sessionIdValue, userNameValue, token) {
+  if (!token) return;
+  localStorage.setItem(getUserTokenStorageKey(sessionIdValue, userNameValue), token);
 }
 
 function getSelectedCardValues() {
@@ -318,18 +332,23 @@ document.getElementById('name').focus();
 
   clearError();
 
+  const storedUserToken = getStoredUserToken(sessionId, userName);
+
   fetch('/join', {
     method: 'POST',
-    body: JSON.stringify({ sessionId, userName }),
+    body: JSON.stringify({ sessionId, userName, userToken: storedUserToken }),
     headers: { 'Content-Type': 'application/json' }
   })
-  .then(res => {
+  .then(async res => {
+    const body = await res.json().catch(() => ({}));
     if (!res.ok) {
-      throw new Error('Unable to reach the session service.');
+      throw new Error(body.error || 'Unable to join session.');
     }
-    return res.json();
+    return body;
   })
-  .then(() => {
+  .then(body => {
+    userToken = body.userToken || storedUserToken;
+    storeUserToken(sessionId, userName, userToken);
     document.getElementById('setup').classList.add('hidden');
     document.getElementById('game').classList.remove('hidden');
     document.getElementById('usernameDisplay').textContent = userName;
@@ -341,7 +360,7 @@ document.getElementById('name').focus();
   })
   .catch(err => {
     console.error('Join session failed:', err);
-    showError('Unable to reach the session service. Please check the worker status and try again.');
+    showError(err.message || 'Unable to reach the session service. Please check the worker status and try again.');
   });
 }
 
@@ -492,7 +511,7 @@ function renderCards() {
 
   fetch('/vote', {
     method: 'POST',
-    body: JSON.stringify({ sessionId, userName, vote: cardConfig.value }),
+    body: JSON.stringify({ sessionId, userName, userToken, vote: cardConfig.value }),
     headers: { 'Content-Type': 'application/json' }
   }).then(() => fetchSessionState());
 };


### PR DESCRIPTION
### Motivation
- Prevent users from spoofing or overwriting other users' votes by tying vote updates to per-user credentials stored in the session. 
- Stop username takeover on join by requiring an existing user's token to rejoin the same display name. 
- Keep session state consistent by removing stale tokens when users are removed.

### Description
- Added a `session.userTokens` map and generate/return a per-user `userToken` from the `POST /join` handler, and reject join attempts for an existing user unless the caller supplies the matching token. 
- Require `userToken` in the `POST /vote` handler and return `403` when the token for `userName` is missing or does not match, preventing unauthorized vote updates. 
- Persist the token cleanup in `POST /remove-user` by deleting the removed user's token from `session.userTokens`. 
- Updated the frontend (`index.html`) to persist tokens in `localStorage`, include the stored token in `/join` requests to reuse existing identity, and send the token with `/vote` requests so legitimate votes continue to work.

### Testing
- Ran `node --check functions/join.js`, `node --check functions/vote.js`, and `node --check functions/remove-user.js`, and all checks completed successfully. 
- Performed local validation of frontend changes by ensuring `localStorage` keys are set and the `join`/`vote` request payloads include `userToken` in integration-like manual runs (no failing automated tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b056043ca08323b0d285aee4d3120a)